### PR TITLE
macOS: Enable Metal validation layers

### DIFF
--- a/fifoci/runner/macos/run_fifo_test.sh
+++ b/fifoci/runner/macos/run_fifo_test.sh
@@ -44,6 +44,10 @@ while [ "$#" -ne 0 ]; do
     # Set LIBVULKAN_PATH to the MoltenVK dylib within the DolphinQt bundle.
     export LIBVULKAN_PATH=$BINARIES/Dolphin.app/Contents/Frameworks/libMoltenVK.dylib
 
+    # Enable all the Metal validation
+    export MTL_DEBUG_LAYER=1
+    export MTL_SHADER_VALIDATION=1
+
     DUMPDIR=$DOLPHIN_EMU_USERPATH/Dump/Frames
     mkdir -p $DUMPDIR
 


### PR DESCRIPTION
Enables Metal's validation layers, to hopefully catch any bad things we try to do before they get merged

Note: If anyone has the ability to prerun fifoci with this change to see if the existing code fails validation before it gets enabled for all CI runs, that would probably be a good idea